### PR TITLE
win-toast-cli: Update to v0.0.2 (#11)

### DIFF
--- a/bucket/win-toast-cli.json
+++ b/bucket/win-toast-cli.json
@@ -1,13 +1,13 @@
 {
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "Invoke toast notification by command-line.",
     "homepage": "https://github.com/MinoruSekine/win-toast-cli",
     "license": {
         "identifier": "AGPL-3.0-or-later",
         "url": "https://www.gnu.org/licenses/agpl-3.0.html"
     },
-    "url": "https://github.com/MinoruSekine/win-toast-cli/releases/download/v0.0.1/win-toast-cli-v0.0.1.zip",
-    "hash": "sha256:db14f3b8c50327d0a1efe4ceea0c7e813bd7061da3ee8eb070f354a25bc0f9a3",
+    "url": "https://github.com/MinoruSekine/win-toast-cli/releases/download/v0.0.2/win-toast-cli-v0.0.2.zip",
+    "hash": "sha256:270a8122453b4eb539f4644f0c1c2bb66847eaac5c3c9fcbc39b6cf1db2b0892",
     "bin": [
         "toast-cli.ps1",
         "tools/toast-scoop-status.ps1"
@@ -17,5 +17,9 @@
     },
     "autoupdate": {
         "url": "https://github.com/MinoruSekine/win-toast-cli/releases/download/v$version/win-toast-cli-v$version.zip"
-    }
+    },
+    "notes": [
+        "win-toast-cli now requires BurntToast.",
+        "If you don't have it, run \"Install-Module -Scope CurrentUser -Name BurntToast\"."
+    ]
 }


### PR DESCRIPTION
Closes #11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.0.2
  * Added dependency requirement on BurntToast with installation instructions when missing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->